### PR TITLE
[FIXED] [BUG] Fix the sizing #676

### DIFF
--- a/style.css
+++ b/style.css
@@ -256,6 +256,7 @@ h2 {
     border-radius: 25px;
     height: 200px;
     width: 100%;
+    padding: 10px;
   }
   
   .list li p {


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #676
I added padding to the images in the list in order to add some space and create a border type effect which makes the images unstuck and makes it visually pleasing.

Before:
<img width="771" alt="Screenshot 2024-11-05 at 7 26 25 PM" src="https://github.com/user-attachments/assets/324a6b04-f194-416a-8fce-c7b49dc0eb3c">

After:
<img width="771" alt="Screenshot 2024-11-05 at 7 26 55 PM" src="https://github.com/user-attachments/assets/22235c39-f644-451a-b238-b4b2a0d4d10d">


<!-- Please provide a Video and ScreenShots for visual changes to speed up reviews -->

## Type of change

<!-- Please delete bullets that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [X] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.